### PR TITLE
Update to react-big-calendar v0.20.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "moment": "^2.22.1",
     "react": "^16.3.2",
-    "react-big-calendar": "^0.19.0",
+    "react-big-calendar": "^0.20.1",
     "react-dom": "^16.3.2",
     "react-scripts": "1.1.4"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import "./App.css";
 import "react-big-calendar/lib/css/react-big-calendar.css";
 import logo from "./logo.svg";
 
-Calendar.setLocalizer(Calendar.momentLocalizer(moment));
+const localizer = Calendar.momentLocalizer(moment);
 
 class App extends Component {
   state = {
@@ -22,14 +22,8 @@ class App extends Component {
   render() {
     return (
       <div className="App">
-        <header className="App-header">
-          <img src={logo} className="App-logo" alt="logo" />
-          <h1 className="App-title">Welcome to React</h1>
-        </header>
-        <p className="App-intro">
-          To get started, edit <code>src/App.js</code> and save to reload.
-        </p>
         <Calendar
+          localizer={localizer}
           defaultDate={new Date()}
           defaultView="month"
           events={this.state.events}


### PR DESCRIPTION
Updated to the latest react-big-calendar and removed the default react heading.